### PR TITLE
Sinatra tracer gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ class SinatraApp < Sinatra::Base
 end
 ```
 
+## Tags
+
+In addition to the standard OpenTracing tags, the instrumentation also adds:
+- `sinatra.template`: the name of the view template, or if rendering a string with view code, the contents of the string.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sinatra::Tracer
 
-Auto-instrumenter for Sinatra applications.
+Auto-instrumenter for Sinatra applications. It traces routes using
+`Rack::Tracer` and patches Sinatra to trace template rendering.
 
 ## Installation
 
@@ -20,7 +21,20 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+In a classic Sinatra application, this can be used by requiring the library:
+
+```ruby
+require 'sinatra/tracer'
+```
+
+A modular application will need to register it manually:
+
+```ruby
+class SinatraApp < Sinatra::Base
+    register Sinatra::Tracer
+    ...
+end
+```
 
 ## Development
 

--- a/lib/sinatra/tracer.rb
+++ b/lib/sinatra/tracer.rb
@@ -1,7 +1,39 @@
-require "sinatra/tracer/version"
+require 'rack/tracer'
+require 'sinatra/base'
+require 'sinatra/tracer/version'
+require 'opentracing'
 
 module Sinatra
   module Tracer
-    # Your code goes here...
+
+    class << self
+
+      def registered(app)
+        # enable the Rack Tracer middleware
+        app.use Rack::Tracer
+
+        patch_render
+      end
+
+      def patch_render
+        ::Sinatra::Base.module_eval do
+          alias_method :render_old, :render
+
+          def render(engine, data, options = {}, locals = {}, &block)
+            result = ""
+
+            OpenTracing.global_tracer.start_active_span("Rendering View") do |scope|
+              result = render_old(engine, data, options, locals, &block)
+              scope.span.set_tag("sinatra.template", data)
+            end
+
+            result
+          end
+        end
+      end
+
+    end
   end
+
+  register Tracer
 end

--- a/lib/sinatra/tracer.rb
+++ b/lib/sinatra/tracer.rb
@@ -17,13 +17,13 @@ module Sinatra
 
       def patch_render
         ::Sinatra::Base.module_eval do
-          alias_method :render_old, :render
+          alias_method :render_original, :render
 
           def render(engine, data, options = {}, locals = {}, &block)
             result = ""
 
             OpenTracing.global_tracer.start_active_span("Rendering View") do |scope|
-              result = render_old(engine, data, options, locals, &block)
+              result = render_original(engine, data, options, locals, &block)
               scope.span.set_tag("sinatra.template", data)
             end
 

--- a/lib/sinatra/tracer.rb
+++ b/lib/sinatra/tracer.rb
@@ -22,7 +22,7 @@ module Sinatra
           def render(engine, data, options = {}, locals = {}, &block)
             result = ""
 
-            OpenTracing.global_tracer.start_active_span("Rendering View") do |scope|
+            OpenTracing.global_tracer.start_active_span("sinatra.render") do |scope|
               result = render_original(engine, data, options, locals, &block)
               scope.span.set_tag("sinatra.template", data)
             end

--- a/sinatra-tracer.gemspec
+++ b/sinatra-tracer.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Tracer for Sinatra applications}
   spec.description   = %q{OpenTracing compatible auto-instrumentation for Sinatra web applications.}
-  spec.homepage      = "http://github.com/achandras/sinatra-tracer"
+  spec.homepage      = "http://github.com/signalfx/sinatra-tracer"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/sinatra-tracer.gemspec
+++ b/sinatra-tracer.gemspec
@@ -40,5 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.60"
   spec.add_development_dependency "rubocop-rspec", "~> 1.30.0"
   spec.add_development_dependency "sinatra", "~> 1.4"
+  spec.add_development_dependency "rack-test", "~> 1.1"
 
 end

--- a/sinatra-tracer.gemspec
+++ b/sinatra-tracer.gemspec
@@ -33,5 +33,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "opentracing_test_tracer", "~> 0.1"
+  spec.add_development_dependency "rack-tracer", "~>0.8.0"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 0.60"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.30.0"
+  spec.add_development_dependency "sinatra", "~> 1.4"
+
 end

--- a/spec/sinatra/tracer_spec.rb
+++ b/spec/sinatra/tracer_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Sinatra::Tracer do
+  describe "Class Methods" do
+    it { should respond_to :registered }
+    it { should respond_to :patch_render }
+  end
+
+  describe :registered do
+    it "adds Rack::Tracer middleware" do
+      expect(Sinatra::Base).to receive(:use).with(Rack::Tracer)
+
+      Sinatra::Tracer.registered(Sinatra::Base)
+    end
+
+    it "calls the patch_render method" do
+      expect(Sinatra::Tracer).to receive(:patch_render)
+
+      Sinatra::Tracer.registered(Sinatra::Base)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,8 @@ require 'sinatra/tracer'
 require 'opentracing_test_tracer'
 
 RSpec.configure do |config|
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'bundler/setup'
+require 'sinatra/tracer'
+require 'opentracing_test_tracer'
+
+RSpec.configure do |config|
+end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -1,0 +1,7 @@
+require 'sinatra/base'
+
+class TestApp < Sinatra::Base
+  get '/' do
+    erb "<h1>Test</h1>"
+  end
+end

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'sinatra', '~> 1.4'
+gem 'jaeger-client', '~> 0.6.1'
+gem 'sinatra-tracer', '~> 0.1.0'

--- a/test_app/hello.rb
+++ b/test_app/hello.rb
@@ -1,0 +1,31 @@
+require 'sinatra'
+require 'opentracing'
+require 'jaeger/client'
+require 'jaeger/client/http_sender'
+require 'logger'
+
+require 'sinatra/tracer'
+
+accessToken = ""
+headers = { }
+service_name = "sinatra-tracer-test"
+encoder = Jaeger::Client::Encoders::ThriftEncoder.new(service_name: service_name)
+httpsender = Jaeger::Client::HttpSender.new(url: "http://localhost:14268/api/traces", headers: headers, encoder: encoder, logger: Logger.new(STDOUT))
+OpenTracing.global_tracer = Jaeger::Client.build(service_name: service_name, sender: httpsender)
+
+get '/' do
+  "#{hello}"
+end
+
+get '/render' do
+  code = "<%= Time.now %>"
+  erb code
+end
+
+def hello
+  hello_str = "hello"
+  OpenTracing.start_active_span("hello") do
+    puts hello_str
+  end
+  hello_str
+end


### PR DESCRIPTION
This uses the Rack::Tracer gem to handle route tracing.

View rendering is traced by patching the `render` method.

There's probably room for more detailed tracing if desired, but routes and rendering seemed like the two most important operations.